### PR TITLE
docs: add note about syncing existing Polar products

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ subscriptions, and may not work as expected with one-time payments. Please
 [open an issue](https://github.com/convex-dev/polar/issues) or [reach out on Discord](https://discord.gg/convex)
 if you run into any issues.
 
-Products created prior to using this component need to be synced with Convex using the `syncProducts` action.
+Products created prior to using this component need to be synced with Convex using the `syncProducts` function.
 
 ### Initialize the Polar client
 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@ subscriptions, and may not work as expected with one-time payments. Please
 [open an issue](https://github.com/convex-dev/polar/issues) or [reach out on Discord](https://discord.gg/convex)
 if you run into any issues.
 
+Products created prior to using this component need to be synced with Convex using the `syncProducts` action.
+
 ### Initialize the Polar client
 
 Create a Polar client in your Convex backend:


### PR DESCRIPTION
Clarifies that pre-existing products must be synced using syncProducts.

<!-- Describe your PR here. -->

Many users after writing the code directly try to see their products, and some have products created before this polar adding flow, this recently created function `syncProducts` is very useful to sync that and I think it should also be mentioned in the flow rather than shown as section in API Reference


<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
