### PR TITLE
fix(react): open checkout with noopener

### DIFF
--- a/src/react/index.tsx
+++ b/src/react/index.tsx
@@ -103,7 +103,7 @@ export const CheckoutLink = ({
           if (embed) {
             await PolarEmbedCheckout.create(url, { theme });
           } else {
-            window.open(url, "_blank");
+            window.open(url, "_blank", "noopener");
           }
         } finally {
           setIsLoading(false);


### PR DESCRIPTION
## Summary

`CheckoutLink` in lazy mode opens the checkout with `window.open(url, "_blank")`. Unlike `<a target="_blank">`, which browsers treat as `noopener` by default, `window.open` still hands the new tab a live `window.opener`, so the checkout page could navigate the page that opened it.

The URL comes from Polar's own API so this is hardening rather than an active issue, but passing `"noopener"` is free: the return value is not used, and the tab opens the same way.

## Test plan

- [x] `tsc --noEmit` and `eslint` clean on the file
- [x] Checked the portal link: it is an `<a target="_blank">`, so it already gets `noopener` implicitly
